### PR TITLE
Initial tweaks

### DIFF
--- a/clasptree.py
+++ b/clasptree.py
@@ -4,6 +4,10 @@ from urllib.parse import quote
 import os
 from glob import glob
 import subprocess
+import shutil
+
+# Determine Python command once at startup
+PYTHON_CMD = "python3" if shutil.which("python3") else "python"
 line = 1
 firstEmit = 1
 indent = ""
@@ -756,7 +760,7 @@ def run():
                 ext = f[1][exti:]
             emit(f"void {cmdargs.prefix}content_{f[0]}(void* {cmdargs.state}) {{{eol}")
             if ext.lower() == ".clasp":
-                cmd = ["python","clasp.py"]
+                cmd = [PYTHON_CMD,"clasp.py"]
                 cmd.append(f"{f[1]}")
                 cmd.append(f"-l unix")
                 cmd.append(f"-b {cmdargs.block}")
@@ -778,7 +782,7 @@ def run():
                 else:
                     indent = oldindent
             else:
-                cmd = ["python","clstat.py"]
+                cmd = [PYTHON_CMD,"clstat.py"]
                 cmd.append(f"{f[1]}")
                 cmd.append("-S 200")
                 cmd.append("-T OK")

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,5 +17,3 @@ build_flags = -std=gnu++17
     -DCAPTIVE_PORTAL_SSID=WeatherStation
     -DLEGACY_I2C ; doesn't seem to work with the new drivers
     ;-DVERBOSE
-upload_port = COM4
-monitor_port = COM4

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ framework = espidf
 lib_deps = codewitch-honey-crisis/htcw_uix
     codewitch-honey-crisis/htcw_json ; in case you need REST/JSON services
 extra_scripts = pre:vite_clasp.py
-upload_speed=921600
+upload_speed=115200
 monitor_speed=115200
 monitor_filters = esp32_exception_decoder
 build_unflags = -std=gnu++11

--- a/src/esp32/captive_portal.c
+++ b/src/esp32/captive_portal.c
@@ -274,11 +274,11 @@ static void parse_url_and_apply(const char* url) {
             }
             if(0==strcmp("ssid",name)) {
                 set_creds=true;
-                strncpy(ssid,value,63);
+                httpd_url_decode(ssid,sizeof(ssid),value);
             }
             if(0==strcmp("pass",name)) {
                 set_creds = true;
-                strncpy(pass,value,63);
+                httpd_url_decode(pass,sizeof(pass),value);
             }
             if(0==strcmp("tz",name)) {
                 set_tz=true;

--- a/src/esp32/ui_captive_portal.cpp
+++ b/src/esp32/ui_captive_portal.cpp
@@ -112,13 +112,4 @@ bool ui_captive_portal_set_ap(const char* address, const char* ssid, const char*
     bool res= display_update_1bit();
     return res;
 }
-bool ui_captive_portal_set_configure(const char* address) {
-    if(xfer_buffer==NULL) return false;
-    setup_label.text("Configure device");
-    setup_qr.text(address);
-    setup_screen.invalidate();
-    setup_screen.update();
-    bool res= display_partial_update_1bit();
-    return res;
-}
 #endif

--- a/src/esp32/ui_captive_portal.cpp
+++ b/src/esp32/ui_captive_portal.cpp
@@ -97,7 +97,6 @@ bool ui_captive_portal_set_ap(const char* address, const char* ssid, const char*
     setup_label.text("Connect to AP to configure:");
     // https://www.wi-fi.org/system/files/WPA3%20Specification%20v3.5.pdf (page 37)
     //WIFI:T:WPA;S:<SSID>;P:<PASS>;;
-    // Per WPA3 spec PDF: WIFI:T:<TYPE>;S:<SSID>;P:<PASS>;;
     strcpy(setup_qr_creds, "WIFI:T:WPA;S:");
     strcat(setup_qr_creds, ssid);
     strcat(setup_qr_creds, ";P:");

--- a/src/esp32/ui_captive_portal.cpp
+++ b/src/esp32/ui_captive_portal.cpp
@@ -52,6 +52,7 @@ bool ui_captive_portal_init() {
     setup_label.color(ucolor_t::black);
     setup_screen.register_control(setup_label);
     setup_qr.bounds(srect16(spoint16::zero(),ssize16(screen_dimensions.width/4,screen_dimensions.width/4)).center_horizontal(setup_screen.bounds()).offset(0,fheight+2));
+    setup_qr.version(4);
         
     setup_cred_url_label.bounds(srect16(0,0,setup_screen.bounds().x2,fheight+1).offset(0,setup_qr.bounds().y2+1));
     setup_cred_url_label.font(text_font);
@@ -93,13 +94,15 @@ void ui_captive_portal_end() {
 }
 bool ui_captive_portal_set_ap(const char* address, const char* ssid, const char* pass) {
     if(xfer_buffer==NULL) return false;
-    setup_label.text("Connect to AP");
-    //WIFI:S:<SSID>;T:<WPA|WEP|>;P:<password>;
-    strcpy(setup_qr_creds,"WIFI:S:");
-    strcat(setup_qr_creds,ssid);
-    strcat(setup_qr_creds,";T:WPA;P:");
-    strcat(setup_qr_creds,pass);
-    strcat(setup_qr_creds,";");
+    setup_label.text("Connect to AP to configure:");
+    // https://www.wi-fi.org/system/files/WPA3%20Specification%20v3.5.pdf (page 37)
+    //WIFI:T:WPA;S:<SSID>;P:<PASS>;;
+    // Per WPA3 spec PDF: WIFI:T:<TYPE>;S:<SSID>;P:<PASS>;;
+    strcpy(setup_qr_creds, "WIFI:T:WPA;S:");
+    strcat(setup_qr_creds, ssid);
+    strcat(setup_qr_creds, ";P:");
+    strcat(setup_qr_creds, pass);
+    strcat(setup_qr_creds, ";;");
     setup_qr.text(setup_qr_creds);
     snprintf(setup_url,sizeof(setup_url)-1,"URL: %s",address);
     setup_cred_url_label.text(setup_url);

--- a/src/esp32/ui_captive_portal.hpp
+++ b/src/esp32/ui_captive_portal.hpp
@@ -7,8 +7,5 @@ bool ui_captive_portal_init();
 /// @brief Sets the initial AP connection screen of the captive portal UI
 /// @return True on success, otherwise false
 bool ui_captive_portal_set_ap(const char* address,const char* ssid, const char* pass);
-/// @brief Sets the configuration screen of the captive portal UI
-/// @return True on success, otherwise false
-bool ui_captive_portal_set_configure(const char* address);
 /// @brief Deinitializes the captive portal UI
 void ui_captive_portal_end();

--- a/vite_clasp.py
+++ b/vite_clasp.py
@@ -15,4 +15,6 @@ else:
 print("ClASP Suite integration enabled")
 
 #env.Execute("dotnet ./build_tools/clasptree.dll ./react-web/dist ./common/include/httpd_content.h --prefix httpd_ --epilogue ./common/include/httpd_epilogue.h --state context --block httpd_send_block --expr httpd_send_expr --handlers extended")
-env.Execute("python clasptree.py ./react-web/dist -o ./include/httpd_content.h -p httpd_ -E ./include/httpd_epilogue.h -s context -b httpd_send_block -e httpd_send_expr -H extended")
+import shutil
+python_cmd = "python3" if shutil.which("python3") else "python"
+env.Execute(f"{python_cmd} clasptree.py ./react-web/dist -o ./include/httpd_content.h -p httpd_ -E ./include/httpd_epilogue.h -s context -b httpd_send_block -e httpd_send_expr -H extended")


### PR DESCRIPTION
various tweaks/fixes

- dev stuff:
  - check for `python3` before `python`
  - lower upload speed (todo: revisit with better cable)
  - autodetect serial (easier for crossplatform development)
- disable screen updates during AP config mode (single static screen is fine and removes long wipes on user connect)
- url decode password/ssid before writing to storage
- force QR Code v4; turns out the ssid/password put us 5 bytes over the v3 limit, making it unscannable.